### PR TITLE
update actions in CI build

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - master
       - main
 
 jobs:
@@ -16,12 +15,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
         with:
-          jvm: adopt:11
+          distribution: temurin
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
@@ -56,12 +56,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+      - name: Setup Java 11
+        uses: actions/setup-java@v3
         with:
-          jvm: adopt:11
+          distribution: temurin
+          java-version: 11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6


### PR DESCRIPTION
old action versions use an old version of nodejs that GitHub is going to disallow (soon)