### PR TITLE
remove incubator footer in docs

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -3,6 +3,8 @@ ThisBuild / scalaVersion := "2.13.14"
 
 enablePlugins(ParadoxPlugin, PekkoParadoxPlugin, ParadoxSitePlugin)
 
+Global / pekkoParadoxIncubatorNotice := None
+
 name := "Pekko Connectors Samples"
 previewFixedPort := Some(8085)
 scmInfo := Some(ScmInfo(url("https://github.com/apache/pekko-connectors-samples"), "git@github.com:apache/pekko-connectors-samples.git"))


### PR DESCRIPTION
The Incubator footer still appears here:
https://nightlies.apache.org/pekko/docs/pekko-connectors-samples/main-snapshot/docs/